### PR TITLE
Make sure the correct bundle is loaded in prod

### DIFF
--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -20,7 +20,7 @@ RCT_REMAP_METHOD(startThread,
 
   int threadId = abs(arc4random());
 
-  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackResource:nil];
+  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackResource:name];
   NSLog(@"starting Thread %@", [threadURL absoluteString]);
 
 


### PR DESCRIPTION
Fixing issue #6 
In prod (or rather when there is no package manger), the fallbackResource is used. And by default that is main.jsbundle. So ensure the thread name is passed along