### PR TITLE
Autolinking & 0.62 support

### DIFF
--- a/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
+++ b/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.devsupport.JSCHeapCapture;
 import com.facebook.react.modules.appstate.AppStateModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
-import com.facebook.react.modules.core.Timing;
+import com.facebook.react.modules.core.TimingModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.intent.IntentModule;
 import com.facebook.react.modules.network.NetworkingModule;
@@ -37,7 +37,7 @@ public class ThreadBaseReactPackage implements ReactPackage {
                 new AndroidInfoModule(catalystApplicationContext),
                 new ExceptionsManagerModule(reactInstanceManager.getDevSupportManager()),
                 new AppStateModule(catalystApplicationContext),
-                new Timing(catalystApplicationContext, reactInstanceManager.getDevSupportManager()),
+                new TimingModule(catalystApplicationContext, reactInstanceManager.getDevSupportManager()),
                 new UIManagerStubModule(catalystApplicationContext),
                 new SourceCodeModule(catalystApplicationContext),
                 new JSCHeapCapture(catalystApplicationContext),
@@ -49,7 +49,7 @@ public class ThreadBaseReactPackage implements ReactPackage {
                 new VibrationModule(catalystApplicationContext),
                 new WebSocketModule(catalystApplicationContext),
                 new ThreadSelfModule(catalystApplicationContext),
-                new DevSettingsModule(reactInstanceManager.getDevSupportManager())
+                new DevSettingsModule(catalystApplicationContext, reactInstanceManager.getDevSupportManager())
         );
     }
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance: 'new RNThreadPackage(reactNativeHost)',
+      },
+    },
+  },
+};


### PR DESCRIPTION
The autolinking change is just the rn config file - that can be added without breaking anything

I the Java changes will only support 0.62 - I'm not sure how you'd make this backwards compatible