### PR TITLE
Fix autolinking on android

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "android/",
     "ios/",
     "js/",
-    "index.js"
+    "index.js",
+    "react-native.config.js"
   ],
   "peerDependencies": {
     "react-native": ">=0.50.0"


### PR DESCRIPTION
The React native config wasn't getting included in the package, so broke autolinking