### PR TITLE
Feature/add v8 support

### DIFF
--- a/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
+++ b/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
@@ -75,7 +75,7 @@ public class ReactContextBuilder {
                 // stop if we were successful
                 hermes.close();
                 return new HermesExecutorFactory();
-            } catch (UnsatisfiedLinkError e) {
+            } catch (UnsatisfiedLinkError|NoClassDefFoundError e) {
                 // try v8
                 return new V8ExecutorFactory();
             }

--- a/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
+++ b/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
@@ -18,6 +18,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.soloader.SoLoader;
+import com.facebook.v8.reactexecutor.V8ExecutorFactory;
 
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
@@ -65,8 +66,19 @@ public class ReactContextBuilder {
             SoLoader.loadLibrary("jscexecutor");
             return new JSCExecutorFactory(appName, deviceName);
         } catch (UnsatisfiedLinkError jscE) {
-            // Otherwise use Hermes
-            return new HermesExecutorFactory();
+            // Otherwise try using hermes
+            try {
+                // we try whether we can start the hermes js executor.
+                // If it fails with an UnsatisfiedLinkError we know
+                // that it is not available.
+                JavaScriptExecutor hermes = new HermesExecutorFactory().create();
+                // stop if we were successful
+                hermes.close();
+                return new HermesExecutorFactory();
+            } catch (UnsatisfiedLinkError e) {
+                // try v8
+                return new V8ExecutorFactory();
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "android/",
     "ios/",
     "js/",
-    "index.js"
+    "index.js",
+    "react-native.config.js"
   ],
   "peerDependencies": {
     "react-native": ">=0.50.0"


### PR DESCRIPTION
This PR makes this library compatible with V8 runtime for react native (https://github.com/Kudo/react-native-v8).

I am not sure whether there is a better implementation for doing the Hermes availability detection than I did. For me, it works using V8!

 I made this based on #110, so this probably needs to be merged first.

