### PR TITLE
Breaking: Update react-native-threads for RN 0.70+ API changes

### DIFF
--- a/RNThread.podspec
+++ b/RNThread.podspec
@@ -1,6 +1,6 @@
 require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+package = JSON.parse(File.read(File.join(__dir__, './package.json')))
 
 Pod::Spec.new do |s|
   s.name           = "RNThread"
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = "https://github.com/joltup/RNThread.git"
   s.source       = { :git => "https://github.com/joltup/RNThread.git", :tag => s.version }
-  s.source_files  = "**/*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m}"
   s.platform      = :ios, "7.0"
   s.tvos.deployment_target = '10.0'
 

--- a/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
+++ b/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.jscexecutor.JSCExecutorFactory;
 import com.facebook.react.bridge.JavaScriptExecutor;
-import com.facebook.react.bridge.NativeModuleCallExceptionHandler;
+import com.facebook.react.bridge.JSExceptionHandler;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
@@ -76,7 +76,7 @@ public class ReactContextBuilder {
         // fresh new react context
         final ReactApplicationContext reactContext = new ReactApplicationContext(parentContext);
         if (devSupportManager != null) {
-            reactContext.setNativeModuleCallExceptionHandler(devSupportManager);
+            reactContext.setJSExceptionHandler(devSupportManager);
         }
 
         // load native modules
@@ -88,9 +88,9 @@ public class ReactContextBuilder {
                 .setJSExecutor(jsExecutor)
                 .setRegistry(nativeRegistryBuilder.build())
                 .setJSBundleLoader(jsBundleLoader)
-                .setNativeModuleCallExceptionHandler(devSupportManager != null
+                .setJSExceptionHandler(devSupportManager != null
                         ? devSupportManager
-                        : createNativeModuleExceptionHandler()
+                        : createJSExceptionHandler()
                 );
 
 
@@ -132,8 +132,8 @@ public class ReactContextBuilder {
         return reactContext;
     }
 
-    private NativeModuleCallExceptionHandler createNativeModuleExceptionHandler() {
-        return new NativeModuleCallExceptionHandler() {
+    private JSExceptionHandler createJSExceptionHandler() {
+        return new JSExceptionHandler() {
             @Override
             public void handleException(Exception e) {
                 throw new RuntimeException(e);

--- a/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
+++ b/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
@@ -9,12 +9,13 @@ import com.facebook.react.modules.appstate.AppStateModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
 import com.facebook.react.modules.core.TimingModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.modules.intent.IntentModule;
 import com.facebook.react.modules.network.NetworkingModule;
-import com.facebook.react.modules.storage.AsyncStorageModule;
 import com.facebook.react.modules.systeminfo.AndroidInfoModule;
 import com.facebook.react.modules.vibration.VibrationModule;
 import com.facebook.react.modules.websocket.WebSocketModule;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.modules.debug.DevSettingsModule;
 
@@ -38,12 +39,12 @@ public class ThreadBaseReactPackage implements ReactPackage {
                 new ExceptionsManagerModule(reactInstanceManager.getDevSupportManager()),
                 new AppStateModule(catalystApplicationContext),
                 new TimingModule(catalystApplicationContext, reactInstanceManager.getDevSupportManager()),
-                new UIManagerStubModule(catalystApplicationContext),
+                new UIManagerModule(catalystApplicationContext, reactInstanceManager.getOrCreateViewManagers(catalystApplicationContext), -1),
+                new DeviceInfoModule(catalystApplicationContext),
                 new SourceCodeModule(catalystApplicationContext),
                 new JSCHeapCapture(catalystApplicationContext),
 
                 // Main list
-                new AsyncStorageModule(catalystApplicationContext),
                 new IntentModule(catalystApplicationContext),
                 new NetworkingModule(catalystApplicationContext),
                 new VibrationModule(catalystApplicationContext),

--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -20,7 +20,9 @@ RCT_REMAP_METHOD(startThread,
 
   int threadId = abs(arc4random());
 
-  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackResource:name];
+  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackURLProvider:^NSURL * {
+    return [[NSBundle mainBundle] URLForResource:name withExtension:@"jsbundle"];
+  }];
   NSLog(@"starting Thread %@", [threadURL absoluteString]);
 
 

--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -26,9 +26,12 @@ RCT_REMAP_METHOD(startThread,
   NSLog(@"starting Thread %@", [threadURL absoluteString]);
 
 
-   RCTBridge *threadBridge = [[RCTBridge alloc] initWithBundleURL:threadURL
+  RCTBridge* currentBridge = RCTBridge.currentBridge;
+  RCTBridge *threadBridge = [[RCTBridge alloc] initWithBundleURL:threadURL
                                             moduleProvider:nil
                                              launchOptions:nil];
+  RCTBridge.currentBridge = currentBridge;
+
 
   ThreadSelfManager *threadSelf = [threadBridge moduleForName:@"ThreadSelfManager"];
   [threadSelf setThreadId:threadId];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "android/",
     "ios/",
     "js/",
-    "index.js"
+    "index.js",
+    "react-native.config.js",
+    "RNThread.podspec"
   ],
   "peerDependencies": {
     "react-native": ">=0.50.0"


### PR DESCRIPTION
This commit revises react-native-threads to accommodate API changes introduced in React Native 0.70+. The update constitutes a breaking change for users on older React Native versions, who will need to use previous react-native-threads versions.